### PR TITLE
Add a beforeTask callback that runs before every task

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,18 @@ new Bundlerify(gulp, {
 }).tasks();
 ```
 
+### Running a callback before every task
+
+```javascript
+new Bundlerify(gulp, {
+    beforeTask: (task, instance) => {
+        // ... do something
+    }
+}).tasks();
+```
+
+This is a utility callback that runs before executing every task. It can be used to change the instance settings depending on the task that it's about to run.
+
 ### Dependencies
 
 Bundlerify uses **thirteen**(*) module dependencies and each and every one of them can be overwritten with a simple getter method.

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -361,24 +361,37 @@ describe('gulp-bundlerify', () => {
      */
     it('should run the clean task', () => {
         const mockRimRaf = jest.genMockFromModule('rimraf');
-        const instance = new Bundlerify(gulp);
+        const mockBeforeTask = jest.genMockFunction();
+        const instance = new Bundlerify(gulp, { beforeTask: mockBeforeTask });
         instance.rimraf = mockRimRaf;
         instance.clean(() => {});
 
         expect(mockRimRaf.mock.calls.length).toEqual(1);
         expect(mockRimRaf.mock.calls[0][0]).toEqual(instance.config.dist.dir);
         expect(mockRimRaf.mock.calls[0][1]).toEqual(jasmine.any(Function));
+
+        expect(mockBeforeTask.mock.calls.length).toEqual(1);
+        expect(mockBeforeTask.mock.calls[0][0]).toEqual('clean');
+        expect(mockBeforeTask.mock.calls[0][1]).toEqual(instance);
+
     });
     /**
      * @test {Bundlerify#lint}
      */
     it('should run the lint task', () => {
         const mockGulp = new BrowserifyMock();
+        const mockBeforeTask = jest.genMockFunction();
         const mockGulpIf = jest.genMockFromModule('gulp-if');
         const mockGulpESLint = jest.genMockFromModule('gulp-eslint');
         const mockGulpJSCS = jest.genMockFromModule('gulp-jscs');
 
-        const instance = new Bundlerify(mockGulp);
+        const instance = new Bundlerify(mockGulp, {
+            beforeTask: mockBeforeTask,
+            tasks: {
+                lint: 'linter',
+            },
+        });
+
         instance.gulpIf = mockGulpIf;
         instance.gulpJSCS = mockGulpJSCS;
         instance.gulpESLint = mockGulpESLint;
@@ -390,18 +403,34 @@ describe('gulp-bundlerify', () => {
         expect(mockGulpESLint.mock.calls.length).toEqual(1);
         expect(mockGulpESLint.format.mock.calls.length).toEqual(1);
         expect(mockGulpJSCS.mock.calls.length).toEqual(1);
+
+        expect(mockBeforeTask.mock.calls.length).toEqual(1);
+        expect(mockBeforeTask.mock.calls[0][0]).toEqual('linter');
+        expect(mockBeforeTask.mock.calls[0][1]).toEqual(instance);
     });
     /**
      * @test {Bundlerify#docs}
      */
     it('should run the docs task', () => {
         const mockESDoc = jest.genMockFromModule('esdoc');
-        const instance = new Bundlerify(gulp);
+        const mockBeforeTask = jest.genMockFunction();
+        const instance = new Bundlerify(gulp, {
+            beforeTask: mockBeforeTask,
+            tasks: {
+                docs: {
+                    name: 'documentation',
+                },
+            },
+        });
         instance.esdoc = mockESDoc;
         instance.docs();
         expect(mockESDoc.generate.mock.calls.length).toEqual(1);
         expect(mockESDoc.generate.mock.calls[0][0]).toEqual(instance.config.esdocOptions);
         expect(mockESDoc.generate.mock.calls[0][1]).toEqual(jasmine.any(Function));
+
+        expect(mockBeforeTask.mock.calls.length).toEqual(1);
+        expect(mockBeforeTask.mock.calls[0][0]).toEqual('documentation');
+        expect(mockBeforeTask.mock.calls[0][1]).toEqual(instance);
     });
     /**
      * @test {Bundlerify#build}

--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,7 @@ export default class Bundlerify {
                 lint: 'lint',
                 docs: 'docs',
             },
+            beforeTask: () => {},
         }, config);
 
         let distRoutePath = this.config.dist.dir;
@@ -275,6 +276,7 @@ export default class Bundlerify {
      * @param  {Function} [callback=null] - An optional callback sent by the Gulp task.
      */
     clean(callback = null) {
+        this._beforeTask('clean');
         this.rimraf(this.config.dist.dir, callback);
     }
     /**
@@ -282,6 +284,7 @@ export default class Bundlerify {
      * @return {Function} It returns the stream used to create and write the build.
      */
     build() {
+        this._beforeTask('build');
         this._watch = false;
         return this._bundle();
     }
@@ -291,6 +294,7 @@ export default class Bundlerify {
      * @return {Function} It returns the stream used to create and write the build.
      */
     serve() {
+        this._beforeTask('serve');
         this._watch = true;
         this._bundler = null;
         this.browserSync(this.config.browserSyncOptions);
@@ -301,6 +305,7 @@ export default class Bundlerify {
      * @return {Function} It returns the stream used to create and write the build.
      */
     lint() {
+        this._beforeTask('lint');
         return this.gulp.src(this.config.lint.target)
         .pipe(this.gulpIf(this.config.lint.eslint, this.gulpESLint()))
         .pipe(this.gulpIf(this.config.lint.eslint, this.gulpESLint.format()))
@@ -311,6 +316,7 @@ export default class Bundlerify {
      * @return {Function} The result of the ESDoc generator.
      */
     docs() {
+        this._beforeTask('docs');
         return this.esdoc.generate(this.config.esdocOptions, this.esdocPublisher);
     }
     /**
@@ -354,6 +360,24 @@ export default class Bundlerify {
         }, this);
 
         return this;
+    }
+    /**
+     * Call the `beforeTask` config callback with the name/alias of a selected task.
+     * @param  {String} taskName - The internal name of the task. It will automatically detect if
+     *                             the name was changed from the config.
+     * @private
+     * @ignore
+     */
+    _beforeTask(taskName) {
+        const task = this.config.tasks[taskName];
+        let taskConfigName = '';
+        if (typeof task === 'object' && task.name) {
+            taskConfigName = task.name;
+        } else {
+            taskConfigName = task;
+        }
+
+        this.config.beforeTask(taskConfigName, this);
     }
     /**
      * This method is called by the constructor and it's used to expand the shorthand settings.


### PR DESCRIPTION
#### What does this PR do?

It adds a callback setting that runs before every task:

``` javascript
new Bundlerify(gulp, {
    beforeTask: (task, instance) => {
        // ... do something
    }
}).tasks();
```

It can be used to change the instance settings depending on the task that it's about to run.
#### How should this be manually tested?
1. You can set a `console.log` on the `beforeTask` so you can see it run before every task.
2. `npm test`.
