### PR TITLE
Added the test task using Jest

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -2,9 +2,6 @@
 
 // __mocks__/fs.js
 
-// Get the real (not mocked) version of the 'path' module
-const path = require.requireActual('path');
-
 // Get the automatic mock for `fs`
 const fsMock = jest.genMockFromModule('fs');
 

--- a/__mocks__/path.js
+++ b/__mocks__/path.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// __mocks__/path.js
+
+// Get the automatic mock for `path`
+const pathMock = jest.genMockFromModule('path');
+
+function resolve(path) {
+    return 'ABSOLUTE/PATH/' + path;
+}
+
+// Override the default behavior of the `resolve` mock
+pathMock.resolve.mockImplementation(resolve);
+
+module.exports = pathMock;

--- a/package.json
+++ b/package.json
@@ -28,16 +28,15 @@
     "babel-eslint": "4.1.4",
     "gulp-jscs": "3.0.2",
     "esdoc": "0.4.3",
-
     "esdoc-es7-plugin": "0.0.3",
-
+    "through2": "2.0.0",
     "whatwg-fetch": "0.10.1",
-    "core-js": "1.2.5"
+    "core-js": "1.2.5",
+    "jest-cli": "0.7.1",
+    "babel-jest": "5.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.1.2",
-    "jest-cli": "0.7.1",
-    "babel-jest": "5.3.0",
     "babel-preset-es2015": "6.1.2",
     "gulp": "3.9.0",
     "eslint": "1.8.0",
@@ -55,7 +54,7 @@
   "jest": {
     "collectCoverage": true,
     "collectCoverageOnlyFrom": {
-      "./src/index.js" : true
+      "src/index.js": true
     },
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "testFileExtensions": [


### PR DESCRIPTION
#### What does this PR do?
- Adds the `test` task to run unit tests using [Jest](https://github.com/facebook/jest).
- Moves `jest-cli` from `devDependencies` to `dependencies` because now it won't only be used for the plugin's tests but also for the project that it's using Bundlerify.
- Updates the documentation with information about the `test` task and `jest`.
- Adds unit tests for the new task.
#### How should this be manually tested?
1. If you have jest unit tests on your demo project, you can set the `jestOptions` setting to your `package.json` and run the `test` task.
2. `npm test`.
