### PR TITLE
ESDoc Uploader and updated babel-jest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - "4.0"
 after_success:
   - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'
+  - '[[ "${TRAVIS_NODE_VERSION}" != "4.1" || "${TRAVIS_BRANCH}" != "master" ]] || npm run deploy-docs'

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Just with that you have all the tasks Bundlerify adds and the basic settings to 
 - `serve`: Watch your Browserify build and run BrowserSync in your demo folder.
 - `lint`: Run JSCS and ESLint for your project.
 - `docs`: It will generate your project documentation using ESDoc.
+- `uploadDocs`: Connects with the [ESDoc Hosting API](https://doc.esdoc.org) and generates your documentation.
 - `clean`: Deletes the distribution directory.
 - `es5`: Instead of making a build with Browserify, compile all the files to ES5.
 - `cleanEs5`: Deletes the ES5 directory.
@@ -224,6 +225,8 @@ new Bundlerify(gulp, {
 }).tasks();
 ```
 
+**Note:** You'll need to have an `esdoc.json` file if you want to use the `uploadDocs` task.
+
 Check the **Extras** section for more information about [ESDoc](https://esdoc.org).
 
 [ESDoc docs](https://esdoc.org/api.html) (:P)
@@ -347,7 +350,7 @@ new Bundlerify(gulp, {
 }).tasks();
 ```
 
-#### - Adding dependencies
+#### - Adding task dependencies
 
 If you want to add extra dependencies tasks to one of Bundlerify tasks, you can use an object with the `deps` keys:
 
@@ -393,7 +396,7 @@ This is a utility callback that runs before executing every task. It can be used
 
 ### Dependencies
 
-Bundlerify uses **sixteen**(*) module dependencies and each and every one of them can be overwritten with a simple getter method.
+Bundlerify uses **seventeen**(*) module dependencies and each and every one of them can be overwritten with a simple getter method.
 
 #### 1 - [Watchify](https://www.npmjs.com/package/watchify)
 
@@ -528,7 +531,16 @@ const b = new Bundlerify(gulp);
 esdocPublisher = myCustomESDocPublisher;
 ```
 
-### 15 - [jest-cli](https://www.npmjs.com/package/jest-cli)
+### 15 - [esdoc-uploader](https://www.npmjs.com/package/esdoc-uploader)
+
+This is a plugin I made and that allows Bundlerify to connect with the [ESDoc Hosting API](https://doc.esdoc.org) in order to generate your project documentation. You can inject your own version by doing this:
+
+```javascript
+const b = new Bundlerify(gulp);
+b.esdocUploader = myCustomUploader;
+```
+
+### 16 - [jest-cli](https://www.npmjs.com/package/jest-cli)
 
 Runs your unit tests suite. You can inject your own version by doing this:
 
@@ -537,7 +549,7 @@ const b = new Bundlerify(gulp);
 b.jest = myCustomJest;
 ```
 
-### 16 - [through2](https://www.npmjs.com/package/through2)
+### 17 - [through2](https://www.npmjs.com/package/through2)
 
 A wrapper for streams that allows the plugin to run `jest-cli` with a stream rather than running the `cli` command. You can inject your own version by doing this:
 
@@ -578,7 +590,7 @@ The short version, it's like JSHint, but it supports plugins :). Like with JSCS,
 
 > ESDoc is a documentation generator for JavaScript(ES6).
 
-that pretty much sums it up, it's a doc generator. Unlike `JSCS` and `ESLint`, you don't _necessarily_ need an `.esdocrc` file, well it uses an `esdoc.json`, but you can set the configuration using the Bundlerify `esdocOptions` setting option. As mentioned on the **Docs** section of this file, if you need/use an external file for the configuration, you give Bundlerify the name of your file as value for `esdocOptions` and it will automatically retrieve those values.
+that pretty much sums it up, it's a doc generator. Unlike `JSCS` and `ESLint`, you don't _necessarily_ need an `.esdocrc` file, well it uses an `esdoc.json`, but you can set the configuration using the Bundlerify `esdocOptions` setting option. As mentioned on the **Docs** section of this file, if you need/use an external file for the configuration, you can give Bundlerify the name of your file as value for `esdocOptions` and it will automatically retrieve those values.
 
 #### Jest
 

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1,13 +1,13 @@
 
 jest.autoMockOff();
 
-const Bundlerify = require('../src/index');
-const BrowserifyMock = require('./utils/browserify.js');
+const Bundlerify = require('../src/index').default;
+const BrowserifyMock = require('./utils/browserify.js').default;
 
 const {
     ESDocUploaderMock,
     ESDocUploaderMockObjs,
-} = require('./utils/esdocUploader.js');
+} = require('./utils/esdocUploader.js').default;
 
 const gulp = require('gulp');
 const originalFs = require('fs');
@@ -42,6 +42,7 @@ describe('gulp-bundlerify', () => {
         expect(instance.build).toEqual(jasmine.any(Function));
         expect(instance.serve).toEqual(jasmine.any(Function));
         expect(instance.tasks).toEqual(jasmine.any(Function));
+        expect(() => Bundlerify(gulp)).toThrow('Cannot call a class as a function');
     });
     /**
      * @test {Bundlerify#config}
@@ -467,7 +468,15 @@ describe('gulp-bundlerify', () => {
     it('should run the clean task', () => {
         const mockRimRaf = jest.genMockFromModule('rimraf');
         const mockBeforeTask = jest.genMockFunction();
-        const instance = new Bundlerify(gulp, { beforeTask: mockBeforeTask });
+        const instance = new Bundlerify(gulp, {
+            beforeTask: mockBeforeTask,
+            tasks: {
+                clean: {
+                    deps: ['randomDep'],
+                },
+            },
+        });
+
         instance.rimraf = mockRimRaf;
         instance.clean(() => {});
 
@@ -486,7 +495,14 @@ describe('gulp-bundlerify', () => {
     it('should run the cleanEs5 task', () => {
         const mockRimRaf = jest.genMockFromModule('rimraf');
         const mockBeforeTask = jest.genMockFunction();
-        const instance = new Bundlerify(gulp, { beforeTask: mockBeforeTask });
+        const instance = new Bundlerify(gulp, {
+            beforeTask: mockBeforeTask,
+            tasks: {
+                cleanEs5: {
+                    name: 'cleanEs5Directory',
+                },
+            },
+        });
         instance.rimraf = mockRimRaf;
         instance.cleanEs5(() => {});
 
@@ -495,7 +511,7 @@ describe('gulp-bundlerify', () => {
         expect(mockRimRaf.mock.calls[0][1]).toEqual(jasmine.any(Function));
 
         expect(mockBeforeTask.mock.calls.length).toEqual(1);
-        expect(mockBeforeTask.mock.calls[0][0]).toEqual('cleanEs5');
+        expect(mockBeforeTask.mock.calls[0][0]).toEqual('cleanEs5Directory');
         expect(mockBeforeTask.mock.calls[0][1]).toEqual(instance);
 
     });
@@ -529,7 +545,7 @@ describe('gulp-bundlerify', () => {
         expect(mockGulpJSCS.mock.calls.length).toEqual(1);
 
         expect(mockBeforeTask.mock.calls.length).toEqual(1);
-        expect(mockBeforeTask.mock.calls[0][0]).toEqual('linter');
+        expect(mockBeforeTask.mock.calls[0][0]).toEqual('lint');
         expect(mockBeforeTask.mock.calls[0][1]).toEqual(instance);
     });
     /**
@@ -591,7 +607,7 @@ describe('gulp-bundlerify', () => {
     /**
      * @test {Bundlerify#uploadDocs}
      */
-    it('should the uploadDocs task', () => {
+    it('should run the uploadDocs task', () => {
         const mockBeforeTask = jest.genMockFunction();
         const mockCallback = jest.genMockFunction();
         const instance = new Bundlerify(gulp, {

--- a/__tests__/utils/esdocUploader.js
+++ b/__tests__/utils/esdocUploader.js
@@ -1,0 +1,44 @@
+/**
+ * A reference to the mock objects the class it's going to use.
+ * @type {Object}
+ */
+const ESDocUploaderMockObjs = {
+    canUploadReturn: true,
+    constructorMock: jest.genMockFunction(),
+    canUploadMock: jest.genMockFunction(),
+    uploadMock: jest.genMockFunction(),
+};
+/**
+ * A special class to mock `esdoc-upload`, because I can't modify the return value of `canUpload`
+ * if it's being instantiated inside Bundlerify.
+ * @version 1.0.0
+ */
+class ESDocUploaderMock {
+    /**
+     * It creates all the mocks and call the one for the constructor.
+     */
+    constructor() {
+
+        ESDocUploaderMockObjs.constructorMock();
+    }
+    /**
+     * Mock the `.canUpload()` method and return the value from  the `.canUploadReturn` property.
+     * @return {Boolean} Whether it can upload the documentation or not.
+     */
+    canUpload() {
+        ESDocUploaderMockObjs.canUploadMock();
+        return ESDocUploaderMockObjs.canUploadReturn;
+    }
+    /**
+     * Mock the `.upload(callback)` method.
+     * @param {Function} callback A callback to be called when the upload process finishes.
+     */
+    upload(callback) {
+        ESDocUploaderMockObjs.uploadMock(callback);
+    }
+}
+
+export default {
+    ESDocUploaderMock: ESDocUploaderMock,
+    ESDocUploaderMockObjs: ESDocUploaderMockObjs,
+};

--- a/dist/index.js
+++ b/dist/index.js
@@ -6,9 +6,9 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
 function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 /**
  * Bundlerify it's something between a generator and a boilerplate for ES6 projects.
@@ -56,12 +56,8 @@ var Bundlerify = (function () {
      * @public
      */
 
-    function Bundlerify(gulp) {
-        var _this = this;
-
+    function Bundlerify(gulp, _x) {
         _classCallCheck(this, Bundlerify);
-
-        var config = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
         /**
          * A reference to the main project's Gulp.
@@ -389,7 +385,7 @@ var Bundlerify = (function () {
 
     _createClass(Bundlerify, [{
         key: 'clean',
-        value: function clean() {
+        value: function clean(_x2) {
             var callback = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
 
             this._beforeTask('clean');
@@ -403,7 +399,7 @@ var Bundlerify = (function () {
 
     }, {
         key: 'cleanEs5',
-        value: function cleanEs5() {
+        value: function cleanEs5(_x3) {
             var callback = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
 
             this._beforeTask('cleanEs5');
@@ -505,7 +501,7 @@ var Bundlerify = (function () {
 
     }, {
         key: 'uploadDocs',
-        value: function uploadDocs() {
+        value: function uploadDocs(_x4) {
             var callback = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
 
             this._beforeTask('uploadDocs');
@@ -786,7 +782,7 @@ var Bundlerify = (function () {
 
     }, {
         key: '_cleanDirectory',
-        value: function _cleanDirectory(path) {
+        value: function _cleanDirectory(path, _x5) {
             var callback = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
 
             this.rimraf(path, callback);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "whatwg-fetch": "0.10.1",
     "core-js": "1.2.6",
     "jest-cli": "0.7.1",
-    "babel-jest": "5.3.0"
+    "babel-jest": "6.0.1"
   },
   "devDependencies": {
     "babel-cli": "6.1.2",
@@ -75,6 +75,9 @@
       "<rootDir>/__tests__/utils",
       "<rootDir>/node_modules/"
     ]
+  },
+  "babel": {
+    "presets": ["es2015"]
   },
   "main": "dist/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "gulp-util": "3.0.7",
     "babelify": "7.2.0",
-    "browser-sync": "2.9.12",
+    "browser-sync": "2.10.0",
     "browserify": "12.0.1",
     "rimraf": "2.4.3",
     "watchify": "3.6.0",
@@ -24,14 +24,15 @@
     "gulp-if": "2.0.0",
     "gulp-uglify": "1.4.2",
     "gulp-streamify": "1.0.2",
-    "gulp-eslint": "1.0.0",
-    "babel-eslint": "4.1.4",
+    "gulp-eslint": "1.1.0",
+    "babel-eslint": "4.1.5",
     "gulp-jscs": "3.0.2",
     "esdoc": "0.4.3",
     "esdoc-es7-plugin": "0.0.3",
+    "esdoc-uploader": "1.0.1",
     "through2": "2.0.0",
     "whatwg-fetch": "0.10.1",
-    "core-js": "1.2.5",
+    "core-js": "1.2.6",
     "jest-cli": "0.7.1",
     "babel-jest": "5.3.0"
   },
@@ -39,17 +40,18 @@
     "babel-cli": "6.1.2",
     "babel-preset-es2015": "6.1.2",
     "gulp": "3.9.0",
-    "eslint": "1.8.0",
-    "jscs": "2.5.0",
+    "eslint": "1.9.0",
+    "jscs": "2.5.1",
     "coveralls": "2.11.4"
   },
   "scripts": {
     "build": "babel --presets es2015 -d dist/ src/",
     "prepublish": "npm run build",
-    "test": "jest ./__tests__/index-test.js",
+    "test": "jest ./__tests__/index-test.js --verbose",
     "coverage": "npm test; open ./coverage/lcov-report/index.html",
-    "lint": "eslint ./src/ ./tests/; jscs ./src/ ./tests/",
-    "docs": "esdoc -c esdoc.json; open docs/index.html"
+    "lint": "eslint ./src/ ./__tests__/; jscs ./src/ ./__tests__/",
+    "docs": "esdoc -c esdoc.json; open docs/index.html",
+    "deploy-docs": "esdoc-uploader"
   },
   "jest": {
     "collectCoverage": true,

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+
 /**
  * Bundlerify it's something between a generator and a boilerplate for ES6 projects.
  * It uses Browserify, Babel, Watchify and BrowserSync, among others, to build your project with
@@ -5,7 +6,6 @@
  * your own dependencies and tasks.
  * @version 1.0.2
  */
-
 export default class Bundlerify {
     /**
      * Create a new instance of the plugin.
@@ -529,10 +529,14 @@ export default class Bundlerify {
     _beforeTask(taskName) {
         const task = this.config.tasks[taskName];
         let taskConfigName = '';
-        if (typeof task === 'object' && task.name) {
-            taskConfigName = task.name;
+        if (typeof task === 'object') {
+            if (task.name) {
+                taskConfigName = task.name;
+            } else {
+                taskConfigName = taskName;
+            }
         } else {
-            taskConfigName = task;
+            taskConfigName = taskName;
         }
 
         this.config.beforeTask(taskConfigName, this);


### PR DESCRIPTION
#### What does this PR do?
- Adds the `uploadDocs` task to generate your documentation with [esdoc-uploader](https://github.com/homer0/esdoc-uploader).
- Updates the documentation.
- Updates `babel-jest` to `v6.0.1`, which updates `babel` to `^6.0.0`, so it required for some of the tests to be updated too.
#### How should this be manually tested?
1. If your demo project is documented with `esdoc` and it's on GitHub, you can try the `uploadDocs` task.
2. `rm -rf node_modules; npm install; npm test`.
