### PR TITLE
Update Babel and fix the build

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,11 @@ var Bundlerify = (function () {
      * @public
      */
 
-    function Bundlerify(gulp, _x) {
+    function Bundlerify(gulp) {
+        var _this = this;
+
+        var config = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
         _classCallCheck(this, Bundlerify);
 
         /**
@@ -385,7 +389,7 @@ var Bundlerify = (function () {
 
     _createClass(Bundlerify, [{
         key: 'clean',
-        value: function clean(_x2) {
+        value: function clean() {
             var callback = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
 
             this._beforeTask('clean');
@@ -399,7 +403,7 @@ var Bundlerify = (function () {
 
     }, {
         key: 'cleanEs5',
-        value: function cleanEs5(_x3) {
+        value: function cleanEs5() {
             var callback = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
 
             this._beforeTask('cleanEs5');
@@ -501,7 +505,7 @@ var Bundlerify = (function () {
 
     }, {
         key: 'uploadDocs',
-        value: function uploadDocs(_x4) {
+        value: function uploadDocs() {
             var callback = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
 
             this._beforeTask('uploadDocs');
@@ -574,10 +578,14 @@ var Bundlerify = (function () {
         value: function _beforeTask(taskName) {
             var task = this.config.tasks[taskName];
             var taskConfigName = '';
-            if ((typeof task === 'undefined' ? 'undefined' : _typeof(task)) === 'object' && task.name) {
-                taskConfigName = task.name;
+            if ((typeof task === 'undefined' ? 'undefined' : _typeof(task)) === 'object') {
+                if (task.name) {
+                    taskConfigName = task.name;
+                } else {
+                    taskConfigName = taskName;
+                }
             } else {
-                taskConfigName = task;
+                taskConfigName = taskName;
             }
 
             this.config.beforeTask(taskConfigName, this);
@@ -782,7 +790,7 @@ var Bundlerify = (function () {
 
     }, {
         key: '_cleanDirectory',
-        value: function _cleanDirectory(path, _x5) {
+        value: function _cleanDirectory(path) {
             var callback = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
 
             this.rimraf(path, callback);
@@ -1195,5 +1203,8 @@ var Bundlerify = (function () {
 
     return Bundlerify;
 })();
+/**
+ * @ignore
+ */
 
 exports.default = Bundlerify;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-jest": "6.0.1"
   },
   "devDependencies": {
-    "babel-cli": "6.1.2",
+    "babel-cli": "6.1.18",
     "babel-preset-es2015": "6.1.2",
     "gulp": "3.9.0",
     "eslint": "1.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
  * your own dependencies and tasks.
  * @version 1.0.2
  */
-export default class Bundlerify {
+class Bundlerify {
     /**
      * Create a new instance of the plugin.
      * @example
@@ -43,7 +43,7 @@ export default class Bundlerify {
      *                                          `mainFile` setting.
      * @public
      */
-    constructor(gulp, config = {}) {
+    constructor(gulp, config={}) {
         /**
          * A reference to the main project's Gulp.
          * @type {Function}
@@ -1055,3 +1055,7 @@ export default class Bundlerify {
         return this._through || this._getDependency('through2');
     }
 }
+/**
+ * @ignore
+ */
+export default Bundlerify;


### PR DESCRIPTION
#### What does this PR do?
- Updates [Babel](http://babeljs.io) to `6.1.18`.
- Changes the main module exportation to `export default Bundlerify` instead of `export default class Bundlerify`, otherwise the constructor default argument (`config`) it's not parsed.
#### How should this be manually tested?

`npm test`.
